### PR TITLE
feat: load MCP resources as context

### DIFF
--- a/pkg/agent/mcp_client.go
+++ b/pkg/agent/mcp_client.go
@@ -55,6 +55,26 @@ func (a *Agent) InitializeMCPClient(ctx context.Context) error {
 	// Store the manager for later use
 	a.mcpManager = manager
 
+	// Fetch resources from connected servers to use as additional context
+	var resourceTexts []string
+	resources, err := manager.ListAvailableResources(ctx)
+	if err != nil {
+		klog.Warningf("Failed to list MCP resources: %v", err)
+	} else {
+		for serverName, resList := range resources {
+			for _, res := range resList {
+				content, err := manager.ReadResource(ctx, serverName, res.URI)
+				if err != nil {
+					klog.Warningf("Failed to read resource %s from server %s: %v", res.URI, serverName, err)
+					continue
+				}
+				resourceTexts = append(resourceTexts, fmt.Sprintf("### %s (%s)\n%s", res.Name, serverName, content))
+			}
+		}
+	}
+
+	a.mcpResourceContext = strings.Join(resourceTexts, "\n\n")
+
 	return nil
 }
 

--- a/pkg/agent/systemprompt_template_default.txt
+++ b/pkg/agent/systemprompt_template_default.txt
@@ -1,5 +1,10 @@
 You are `kubectl-ai`, an AI assistant with expertise in operating and performing actions against a kubernetes cluster. Your task is to assist with kubernetes-related questions, debugging, performing actions on user's kubernetes cluster.
 
+{{if .MCPResourceText }}
+## External context
+{{.MCPResourceText}}
+{{end}}
+
 {{if .EnableToolUseShim }}
 ## Available tools
 <tools>

--- a/pkg/mcp/http_client.go
+++ b/pkg/mcp/http_client.go
@@ -244,6 +244,28 @@ func (c *httpClient) ListTools(ctx context.Context) ([]Tool, error) {
 	return tools, nil
 }
 
+// ListResources lists all available resources from the MCP server
+func (c *httpClient) ListResources(ctx context.Context) ([]Resource, error) {
+	resources, err := listClientResources(ctx, c.client, c.name)
+	if err != nil {
+		return nil, err
+	}
+
+	klog.V(2).InfoS("Listed resources from HTTP MCP server", "count", len(resources), "server", c.name)
+	return resources, nil
+}
+
+// ReadResource reads a resource from the MCP server and returns its text content
+func (c *httpClient) ReadResource(ctx context.Context, uri string) (string, error) {
+	klog.V(2).InfoS("Reading MCP resource via HTTP", "server", c.name, "uri", uri)
+
+	if err := c.ensureConnected(); err != nil {
+		return "", err
+	}
+
+	return readClientResource(ctx, c.client, uri)
+}
+
 // CallTool calls a tool on the MCP server and returns the result as a string
 func (c *httpClient) CallTool(ctx context.Context, toolName string, arguments map[string]interface{}) (string, error) {
 	klog.V(2).InfoS("Calling MCP tool via HTTP", "server", c.name, "tool", toolName)

--- a/pkg/mcp/interfaces.go
+++ b/pkg/mcp/interfaces.go
@@ -38,6 +38,12 @@ type MCPClient interface {
 	// CallTool calls a tool on the MCP server and returns the result as a string
 	CallTool(ctx context.Context, toolName string, arguments map[string]interface{}) (string, error)
 
+	// ListResources lists all available resources from the MCP server
+	ListResources(ctx context.Context) ([]Resource, error)
+
+	// ReadResource reads a resource from the MCP server and returns its text content
+	ReadResource(ctx context.Context, uri string) (string, error)
+
 	// ensureConnected makes sure the client is connected
 	ensureConnected() error
 

--- a/pkg/mcp/stdio_client.go
+++ b/pkg/mcp/stdio_client.go
@@ -141,6 +141,28 @@ func (c *stdioClient) ListTools(ctx context.Context) ([]Tool, error) {
 	return tools, nil
 }
 
+// ListResources lists all available resources from the MCP server
+func (c *stdioClient) ListResources(ctx context.Context) ([]Resource, error) {
+	resources, err := listClientResources(ctx, c.client, c.name)
+	if err != nil {
+		return nil, err
+	}
+
+	klog.V(2).InfoS("Listed resources from stdio MCP server", "count", len(resources), "server", c.name)
+	return resources, nil
+}
+
+// ReadResource reads a resource from the MCP server and returns its text content
+func (c *stdioClient) ReadResource(ctx context.Context, uri string) (string, error) {
+	klog.V(2).InfoS("Reading MCP resource via stdio", "server", c.name, "uri", uri)
+
+	if err := c.ensureConnected(); err != nil {
+		return "", err
+	}
+
+	return readClientResource(ctx, c.client, uri)
+}
+
 // CallTool calls a tool on the MCP server and returns the result as a string
 func (c *stdioClient) CallTool(ctx context.Context, toolName string, arguments map[string]interface{}) (string, error) {
 	klog.V(2).InfoS("Calling MCP tool via stdio", "server", c.name, "tool", toolName)


### PR DESCRIPTION
## Summary
- fetch and read MCP resources from connected servers
- include resource text in system prompt for added context
- expose resource list/read operations in MCP manager and clients

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6891250692e0832ba3fe47ef9ac03269