### PR TITLE
fix: prevent RunOnce mode from hanging by sending exit message to Output channel

### DIFF
--- a/pkg/agent/conversation.go
+++ b/pkg/agent/conversation.go
@@ -437,6 +437,10 @@ func (c *Agent) Run(ctx context.Context, initialQuery string) error {
 				if c.RunOnce {
 					log.Info("RunOnce mode, exiting agent loop")
 					c.setAgentState(api.AgentStateExited)
+					// Send a message to unblock the UI goroutine waiting on Output channel.
+					// Without this, the UI would hang forever since it only checks AgentState
+					// after receiving a message from the Output channel.
+					c.addMessage(api.MessageSourceAgent, api.MessageTypeText, "It has been a pleasure assisting you. Have a great day!")
 					return
 				}
 				log.Info("initiating user input")


### PR DESCRIPTION
When the agent finishes in RunOnce mode, it sets AgentStateExited and returns
without sending any message to the Output channel. However, the TerminalUI
goroutine is blocked reading from the Output channel and only checks AgentState
after receiving a message. This causes a deadlock where:

1. Agent sets state to Exited and returns (no message sent)
2. UI goroutine blocks on <-agent.Output (waiting for message)
3. UI never checks AgentState, never closes agentExited channel
4. Run() blocks on <-agentExited forever

The fix sends a farewell message before returning, which unblocks the UI
goroutine, allows it to check the state, and properly exit.